### PR TITLE
Adds keepTopDir option

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,18 @@ module.exports = function(opts) {
 
   return through2.obj(function(file, enc, next) {
     try {
-      file.path = path.join(file.base, opts.newPath, path.basename(file.path));
+      var topDir = "";
+
+      if(opts.keepTopDir)
+      {
+        var relPath = path.relative(file.base, file.path);
+        topDir = relPath.split(/[\/\\\\]/)[0];
+        
+        if(topDir == path.basename(file.path))
+          topDir = "";
+      }
+
+      file.path = path.join(file.base, opts.newPath, topDir, path.basename(file.path));
       this.push(file);
     } catch (e) {
       this.emit('error', new PluginError('gulp-flatten', e));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-flatten",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "remove or replace relative path for files",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This option makes it easy to group a component's files inside a folder. E.g., select2 has a lot of files that need to be deployed.  Now they can be nicely organised inside a "select2" folder.
